### PR TITLE
enable gmd conversion on all platforms

### DIFF
--- a/src/GMD.cpp
+++ b/src/GMD.cpp
@@ -1,6 +1,7 @@
 #include "Shared.hpp"
 #include <GMD.hpp>
 #include <Geode/utils/file.hpp>
+#include <Geode/utils/base64.hpp>
 #include <Geode/binding/MusicDownloadManager.hpp>
 #include <Geode/utils/JsonValidation.hpp>
 #include <Geode/cocos/support/base64.h>
@@ -179,24 +180,13 @@ geode::Result<GJGameLevel*> ImportGmdFile::intoLevel() const {
     level->m_isEditable = true;
     level->m_levelType = GJLevelType::Editor;
 
-#ifdef GEODE_IS_WINDOWS
     // old gdshare double base64 encoded the description,
     // so we decode it again
     if (isOldFile && level->m_levelDesc.size()) {
-        unsigned char* out = nullptr;
-        // we really should add some base64 utils, this is nasty
-        auto size = cocos2d::base64Decode(
-            reinterpret_cast<unsigned char*>(const_cast<char*>(level->m_levelDesc.c_str())),
-            level->m_levelDesc.size(),
-            &out
-        );
-        if (out) {
-            auto newDesc = std::string(reinterpret_cast<char*>(out), size);
-            free(out);
-            level->m_levelDesc = newDesc;
+        if(auto res = base64::decodeString(level->m_levelDesc)) {
+            level->m_levelDesc = res.unwrap();
         }
     }
-#endif
 
     return Ok(level);
 }


### PR DESCRIPTION
This PR enables proper pre-Geode GDShare .gmd file conversion on non-Windows platforms making it possible for these users to import their old .gmd files as well.

(This also makes it possible to import GDHistory .gmds on there, as the website exports .gmds in the legacy format to maintain compatibility for 2.1 users)