### PR TITLE
add partial support for pre-1.9 gmds

### DIFF
--- a/src/GMD.cpp
+++ b/src/GMD.cpp
@@ -198,6 +198,11 @@ geode::Result<GJGameLevel*> ImportGmdFile::intoLevel() const {
     }
 #endif
 
+    // this is required for supporting pre-1.9 gmds
+    if(!level->m_levelString.size()) {
+        level->m_levelString = dict.get()->getStringForKey("k4");
+    }
+
     return Ok(level);
 }
 


### PR DESCRIPTION
This PR adds partial support for .gmds exported from Geometry Dash versions before GD 1.9. Previously if the binary version of a .gmd file was set to a version before 1.9, the upgrade mechanism would wipe the levelString and mangle the description - mangling the description may still happen with this PR due to the inconsistency of the desc format in 3rd party exporters (some base64 it like 2.0+ and some don't), however this PR ensures that the levelString is properly imported.

Real life use case: .gmd files exported from GDBrowser when a pre-1.9 save file is loaded