### PR TITLE
add stars sanitization

### DIFF
--- a/src/GMD.cpp
+++ b/src/GMD.cpp
@@ -178,6 +178,11 @@ geode::Result<GJGameLevel*> ImportGmdFile::intoLevel() const {
 
     level->m_isEditable = true;
     level->m_levelType = GJLevelType::Editor;
+    level->m_stars = 0;
+    level->m_demon = 0;
+    level->m_dailyID = 0;
+    level->m_gauntletLevel = false;
+    level->m_gauntletLevel2 = false;
 
 #ifdef GEODE_IS_WINDOWS
     // old gdshare double base64 encoded the description,


### PR DESCRIPTION
This PR makes it so imported editor levels are not able to award stars and orbs. This sanitization would probably be better fit for GDShare itself, but since GMD-API already makes other changes required for the level to show properly in the Created tab, they have been included there for consistency.